### PR TITLE
[mono] Fix finding packages in lower-case dirs on case-sensitive ..

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
         public string Id { get; }
         public string Version { get; }
+        public string RelativePackagePath => (string)LibraryObject["path"];
         
         /// <summary>
         /// The JSON object from the "targets" section in the project.lock.json for this package.

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -369,7 +369,7 @@ namespace Microsoft.NuGet.Build.Tasks
                         if (Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
                         {
                             string path;
-                            if (TryGetFile(package.Id, package.Version, file, out path))
+                            if (TryGetFile(package.Id, package.Version, package.RelativePackagePath, file, out path))
                             {
                                 var analyzer = new TaskItem(path);
 
@@ -441,16 +441,16 @@ namespace Microsoft.NuGet.Build.Tasks
             }
         }
 
-        private bool TryGetFile(string packageName, string packageVersion, string file, out string path)
+        private bool TryGetFile(string packageName, string packageVersion, string packageRelativePath, string file, out string path)
         {
             if (IsFileValid(file, "C#", "VB"))
             {
-                path = GetPath(packageName, packageVersion, file);
+                path = GetPath(packageName, packageVersion, packageRelativePath, file);
                 return true;
             }
             else if (IsFileValid(file, "VB", "C#"))
             {
-                path = GetPath(packageName, packageVersion, file);
+                path = GetPath(packageName, packageVersion, packageRelativePath, file);
                 return true;
             }
 
@@ -469,9 +469,9 @@ namespace Microsoft.NuGet.Build.Tasks
                             !file.Split('/').Any(x => x.Equals(unExpectedLanguage, StringComparison.OrdinalIgnoreCase)));
         }
 
-        private string GetPath(string packageName, string packageVersion, string file)
+        private string GetPath(string packageName, string packageVersion, string packageRelativePath, string file)
         {
-            return Path.Combine(GetNuGetPackagePath(packageName, packageVersion), file.Replace('/', Path.DirectorySeparatorChar));
+            return Path.Combine(GetNuGetPackagePath(packageName, packageVersion, packageRelativePath), file.Replace('/', Path.DirectorySeparatorChar));
         }
 
         /// <summary>
@@ -932,17 +932,23 @@ namespace Microsoft.NuGet.Build.Tasks
             }
         }
 
-        private string GetNuGetPackagePath(string packageId, string packageVersion)
+        private string GetNuGetPackagePath(string packageId, string packageVersion, string packageRelativePath)
         {
+            string relativePathToUse = String.IsNullOrEmpty(packageRelativePath)
+                                            ? Path.Combine(packageId, packageVersion)
+                                            : packageRelativePath.Replace('/', Path.DirectorySeparatorChar);
+
+            string hashFileName = $"{packageId.ToLowerInvariant()}.{packageVersion.ToLowerInvariant()}.nupkg.sha512";
+
             foreach (var packagesFolder in _packageFolders)
             {
-                string packagePath = Path.Combine(packagesFolder, packageId, packageVersion);
+                string packageFullPath = Path.Combine(packagesFolder, relativePathToUse);
 
                 // The proper way to check if a package is available is to look for the hash file, since that's the last
                 // file written as a part of the restore process. If it's not there, it means something failed part way through.
-                if (_fileExists(Path.Combine(packagePath, $"{packageId}.{packageVersion}.nupkg.sha512")))
+                if (_fileExists(Path.Combine(packageFullPath, hashFileName)))
                 {
-                    return packagePath;
+                    return packageFullPath;
                 }
             }
 
@@ -972,7 +978,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 }
                 else
                 {
-                    fullPackagePathGenerator = () => GetNuGetPackagePath(id, version);
+                    fullPackagePathGenerator = () => GetNuGetPackagePath(id, version, (string)libraryObject["path"]);
                 }
 
                 yield return new NuGetPackageObject(id, version, fullPackagePathGenerator, (JObject)package.Value, libraryObject);


### PR DESCRIPTION
.. filesystems.

NuGet now restores packages in lower case directory names, but the
build task `ResolveNuGetPackageAssets` constructs the path from package
name and version, like:

    `Microsoft.NETCore.Portable.Compatibility/1.0.1`

.. instead of

    `microsoft.netcore.portable.compatibility/1.0.1`

This breaks builds on msbuild/mono on case-sensitive filesystems, eg. on
Linux.

The actual on-disk path is available in the lock/assets.json file as:

```
"libraries": {
"Newtonsoft.Json/10.0.2": {
  ...
  "path": "newtonsoft.json/10.0.2",
  ...
```

So, we use that to look for the package. But fallback to the old method if this
`"path"` is not available.